### PR TITLE
Fix false clavicle-side validation for shared center roots

### DIFF
--- a/tools/blender_fix_spine_bones.py
+++ b/tools/blender_fix_spine_bones.py
@@ -795,16 +795,24 @@ def validation_for_armature(armature: bpy.types.Object, added_bones: set[str] | 
                     f"({drift:.4f} > {max_drift:.4f}); spine assignment is likely wrong."
                 )
 
-    def side_check(right: str, left: str, label: str) -> None:
+    def side_check(right: str, left: str, label: str, *, use_midpoint: bool = False) -> None:
         if right not in bones or left not in bones:
             warnings.append(f"Could not validate {label} left/right side because one landmark is missing.")
             return
-        right_x = float(bones[right].head_local.x)
-        left_x = float(bones[left].head_local.x)
+        right_bone = bones[right]
+        left_bone = bones[left]
+        if use_midpoint:
+            # Clavicles can share a chest-center head, so their segment
+            # midpoints carry the side information without relying on direction.
+            right_x = (float(right_bone.head_local.x) + float(right_bone.tail_local.x)) * 0.5
+            left_x = (float(left_bone.head_local.x) + float(left_bone.tail_local.x)) * 0.5
+        else:
+            right_x = float(right_bone.head_local.x)
+            left_x = float(left_bone.head_local.x)
         if not (right_x < left_x):
             errors.append(f"{label} side appears swapped: expected {right} on negative X and {left} on positive X.")
 
-    side_check(R_CLAVICLE, L_CLAVICLE, "clavicle")
+    side_check(R_CLAVICLE, L_CLAVICLE, "clavicle", use_midpoint=True)
     side_check(R_THIGH, L_THIGH, "leg")
     for target in added_bones:
         warnings.append(f"{target} was added as an unweighted deform bone.")

--- a/tools/blender_sort_bones.py
+++ b/tools/blender_sort_bones.py
@@ -644,14 +644,24 @@ def spine_validation(armature: bpy.types.Object) -> dict[str, object]:
         if parent in indexes and indexes[parent] > indexes[target]:
             errors.append(f"{parent} appears after child {target} in armature.data.bones order.")
 
-    def side_check(right: str, left: str, label: str) -> None:
+    def side_check(right: str, left: str, label: str, *, use_midpoint: bool = False) -> None:
         if right not in bones or left not in bones:
             warnings.append(f"Could not validate {label} side because a landmark is missing.")
             return
-        if float(bones[right].head_local.x) >= float(bones[left].head_local.x):
+        right_bone = bones[right]
+        left_bone = bones[left]
+        if use_midpoint:
+            # Clavicles can share a chest-center head, so their segment
+            # midpoints carry the side information without relying on direction.
+            right_x = (float(right_bone.head_local.x) + float(right_bone.tail_local.x)) * 0.5
+            left_x = (float(left_bone.head_local.x) + float(left_bone.tail_local.x)) * 0.5
+        else:
+            right_x = float(right_bone.head_local.x)
+            left_x = float(left_bone.head_local.x)
+        if right_x >= left_x:
             errors.append(f"{label} side appears swapped: expected {right} on negative X and {left} on positive X.")
 
-    side_check(R_CLAVICLE, L_CLAVICLE, "clavicle")
+    side_check(R_CLAVICLE, L_CLAVICLE, "clavicle", use_midpoint=True)
     side_check(R_THIGH, L_THIGH, "leg")
     return {"ok": not errors, "errors": errors, "warnings": warnings}
 


### PR DESCRIPTION
Thank you for maintaining this importer. I encountered a narrow false-positive validation case in Step 3 and have kept this change deliberately limited to that geometry check and its Step 4 counterpart.

## Summary

Some valid rigs place both clavicle heads at the same chest-center point, with each clavicle extending outward to its correct side. The current validator compares only `head_local.x`, so equal center heads are reported as swapped even when the complete bone segments are correctly positioned.

This PR uses each clavicle segment's X midpoint for the side comparison:

```python
(head_local.x + tail_local.x) * 0.5
```

The existing relative ordering rule is preserved: the right-side value must be less than the left-side value.

## Reproduction evidence

On the reproducing rig, the clavicle coordinates after the spine repair were:

| Bone | Head X | Tail X | Segment midpoint X |
|---|---:|---:|---:|
| `ValveBiped.Bip01_R_Clavicle` | `0.000000` | `-0.088449` | `-0.0442245` |
| `ValveBiped.Bip01_L_Clavicle` | `0.000000` | `+0.089475` | `+0.0447375` |

The previous test effectively evaluated `0.0 < 0.0`, which is false, and emitted:

`clavicle side appears swapped: expected ValveBiped.Bip01_R_Clavicle on negative X and ValveBiped.Bip01_L_Clavicle on positive X.`

The full segments are not swapped: their midpoints correctly satisfy `-0.0442245 < +0.0447375`.

## Exact changes

The same narrow adjustment is applied to both places that validate the canonical spine attachments:

- `tools/blender_fix_spine_bones.py`
  - `validation_for_armature()`
  - its local `side_check()` now accepts `use_midpoint=False`
  - only the clavicle call opts into `use_midpoint=True`

- `tools/blender_sort_bones.py`
  - `spine_validation()`
  - its local `side_check()` receives the same opt-in behavior
  - only the clavicle call opts into `use_midpoint=True`

The Step 3 and Step 4 checks remain consistent, so a rig accepted after spine repair is not rejected later during bone sorting for the original head-only reason.

## Why use the segment midpoint only for clavicles?

A midpoint represents the lateral placement of the whole bone segment rather than only one endpoint. For clavicles, this is useful because both bones may legitimately begin at the same chest-center junction.

It also has two useful invariants:

- Reversing a bone's head and tail does not change its midpoint.
- Translating the entire rig along X does not change the right-versus-left ordering.

I considered a few smaller-looking alternatives:

- Allowing equal clavicle heads, or adding a tolerance, would remove this false positive but could also accept genuinely swapped or laterally ambiguous segments.
- Comparing only `tail_local.x` would depend on which endpoint the source rig treats as the tail.
- Comparing `tail_local.x - head_local.x` would depend on bone direction and would invert when the endpoints are reversed.
- Applying midpoint comparison to every side landmark would unnecessarily change the established thigh validation. Thigh heads normally carry the intended side information, while shared center roots are specifically relevant to clavicles.

For that reason, midpoint behavior is an explicit clavicle-only option and the leg check remains unchanged.

## Scope

This is validation-only:

- no bones are moved, renamed, added, deleted, or reparented;
- no vertex weights or mapping rules are changed;
- genuinely swapped clavicle segments are still rejected;
- leg-side validation is unchanged;
- no build artifacts or model fixtures are included.

## Validation

Tests were run with Blender 4.5.10 LTS against both validation functions.

| Case | Step 3 `validation_for_armature()` | Step 4 `spine_validation()` |
|---|---|---|
| Valid clavicles with shared center heads | Accepted | Accepted |
| Complete right/left segments swapped | Rejected | Rejected |
| Correctly sided segments with head/tail direction reversed | Accepted | Accepted |
| Correctly sided rig translated along X | Accepted | Accepted |
| Coincident, zero-lateral-width clavicle segments | Rejected as ambiguous | Rejected as ambiguous |

The original reproducer was also run through the relevant workflow:

- Before the patch, Step 3 repair ended with the clavicle-side error shown above.
- With the patch, Step 3 apply completed successfully. The only remaining messages were the existing warnings for two added unweighted spine bones.
- Step 4 analysis completed with no validation errors.
- Step 4 apply completed with no validation errors after its planned bone merges.
- `python -m py_compile tools/blender_fix_spine_bones.py tools/blender_sort_bones.py` passes.
- `git diff --check` passes.

## Related issue

This may address the clavicle-side diagnostic visible in #142. However, that report uses a different model and also contains a separate `leg side appears swapped` error, which this PR intentionally does not change. I therefore have not marked this as fully fixing or closing #142.

Thank you for considering the change. If you would prefer a different geometry rule or code structure, I would be very happy to adjust the implementation.
